### PR TITLE
Run V2Ray as non-root user

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir /var/log/v2ray/ \
     && chown -R v2ray_user:v2ray_user /usr/bin/v2ray/ \
     && chown -R v2ray_user:v2ray_user /etc/v2ray/ \
     && chown -R v2ray_user:v2ray_user /var/log/v2ray/
-
+RUN apk del bash;
 
 ENV PATH /usr/bin/v2ray:$PATH
 

--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -5,9 +5,17 @@ MAINTAINER admin@v2ray.com
 COPY v2ray /usr/bin/v2ray/
 COPY config.json /etc/v2ray/config.json
 
+RUN apk --update add bash;
 RUN mkdir /var/log/v2ray/ \
-    && chmod +x /usr/bin/v2ray/v2ray
+    && chmod +x /usr/bin/v2ray/v2ray \
+    && adduser -D -H -s /bin/false v2ray_user v2ray_user \
+    && chown -R v2ray_user:v2ray_user /usr/bin/v2ray/ \
+    && chown -R v2ray_user:v2ray_user /etc/v2ray/ \
+    && chown -R v2ray_user:v2ray_user /var/log/v2ray/
+
 
 ENV PATH /usr/bin/v2ray:$PATH
+
+USER v2ray_user
 
 CMD ["v2ray", "-config=/etc/v2ray/config.json"]

--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -5,14 +5,14 @@ MAINTAINER admin@v2ray.com
 COPY v2ray /usr/bin/v2ray/
 COPY config.json /etc/v2ray/config.json
 
-RUN apk --update add bash;
-RUN mkdir /var/log/v2ray/ \
+RUN apk --update add bash \
+    && mkdir /var/log/v2ray/ \
     && chmod +x /usr/bin/v2ray/v2ray \
     && adduser -D -H -s /bin/false v2ray_user v2ray_user \
     && chown -R v2ray_user:v2ray_user /usr/bin/v2ray/ \
     && chown -R v2ray_user:v2ray_user /etc/v2ray/ \
-    && chown -R v2ray_user:v2ray_user /var/log/v2ray/
-RUN apk del bash;
+    && chown -R v2ray_user:v2ray_user /var/log/v2ray/ \
+    && apk del bash
 
 ENV PATH /usr/bin/v2ray:$PATH
 


### PR DESCRIPTION
It is not a good idea to run v2ray in docker container with root privileges. It is not hard to escape from docker container when root privileges are granted.  If the attacker found some vulnerabilities from V2Ray, they may escape the container and gain the control to the host.

This modification creates a non-root user and use that to run v2ray.