### PR TITLE
Fix:failed to load system roots and no roots provided

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -5,8 +5,10 @@ MAINTAINER admin@v2ray.com
 COPY v2ray /usr/bin/v2ray/
 COPY config.json /etc/v2ray/config.json
 
-RUN mkdir /var/log/v2ray/ \
-    && chmod +x /usr/bin/v2ray/v2ray
+RUN set -ex && \
+    apk --no-cache add ca-certificates && \
+    mkdir /var/log/v2ray/ &&\
+    chmod +x /usr/bin/v2ray/v2ray
 
 ENV PATH /usr/bin/v2ray:$PATH
 


### PR DESCRIPTION
使用v2ray/official用作中转的时候，如果被中转服务器启用了Let‘s Encrypt证书的TLS加密，中转服务器作为`outbound`连接，可能会出现`failed to dial to (xxxxxxx):  > x509: failed to load system roots and no roots provided]`错误，添加CA以解决此问题。