### PR TITLE
Add 'chmod +x /usr/bin/v2ray/v2ctl' to Dockerfile

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -12,6 +12,7 @@ COPY config.json /etc/v2ray/config.json
 RUN set -ex && \
     apk --no-cache add ca-certificates && \
     mkdir /var/log/v2ray/ &&\
+    chmod +x /usr/bin/v2ray/v2ctl && \
     chmod +x /usr/bin/v2ray/v2ray
 
 ENV PATH /usr/bin/v2ray:$PATH


### PR DESCRIPTION
To fix a `fork exec permission denied` error