### PR TITLE
Expose all tcp & udp ports to make rkt happy

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -9,6 +9,9 @@ ADD https://storage.googleapis.com/v2ray-docker/geosite.dat /usr/bin/v2ray/
 
 COPY config.json /etc/v2ray/config.json
 
+EXPOSE 1-65535/tcp
+EXPOSE 1-65535/udp
+
 RUN set -ex && \
     apk --no-cache add ca-certificates && \
     mkdir /var/log/v2ray/ &&\


### PR DESCRIPTION
When run docker image with rkt, only predefined port is  accessible(see rkt/rkt#2113). With dynamic port allocate nature of v2ray, we should expose all possible ports.
